### PR TITLE
Add tzdata dependency so kafka-to-nexus can resolve timezone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:17.10
 
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get -y install clang-format cloc cmake cppcheck doxygen g++ git graphviz lcov python-pip valgrind vim-common && \
+    apt-get -y install clang-format cloc cmake cppcheck doxygen g++ git graphviz lcov python-pip valgrind vim-common tzdata && \
     apt-get -y autoremove && \
     apt-get clean all
 


### PR DESCRIPTION
Adding `tzdata` dependency in the Ubuntu 16.04 image successfully solved a problem with kafka-to-nexus not being able to resolve the timezone in the container, it will also be needed in this image.